### PR TITLE
Include context into properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,34 @@
+const contextMapping = {
+  'ip': '$ip',
+  'page.url': '$current_url',
+  'page.path': '$pathname',
+  'os.name': '$os',
+  'page.referrer': '$referrer',
+  'screen.width': '$screen_width',
+  'screen.height': '$screen_height',
+  'device.type': '$device_type'
+}
+
+function parseContext(context) {
+  if(!context) {
+    return {}
+  }
+  let ret = {}
+  if(context.campaign) {
+    Object.entries(context.campaign).map(function([key, value]) {
+      ret['utm_' + key] = value
+    })
+    delete context['campaign']
+  }
+  
+  Object.entries(contextMapping).map(function([key, value]) {
+    ret[value] = _.get(context, key)
+  })
+  
+  // Remove all mapped properties to reduce noise
+  context = _.omit(context, Object.keys(contextMapping))
+  return {...ret, ...context}
+}
 /**
  * @param {SpecTrack} event The track event
  * @param {Object.<string, any>} settings Custom settings
@@ -16,8 +47,10 @@ async function onTrack(event, settings) {
             ...event,
             api_key: settings.apiKey,
             properties: {
+                ...parseContext(event.context),
                 ...event.properties,
                 distinct_id: event.userId || event.anonymousId,
+                $lib: 'Segment'
             },
         }),
         headers: new Headers({

--- a/index.js
+++ b/index.js
@@ -25,8 +25,10 @@ function parseContext(context) {
     ret[value] = _.get(context, key)
   })
   
-  // Remove all mapped properties to reduce noise
-  context = _.omit(context, Object.keys(contextMapping))
+  // prepend all keys with segment_
+  context = _.mapKeys(context, function(value, key) {
+    return 'segment_' + key
+  })
   return {...ret, ...context}
 }
 /**


### PR DESCRIPTION
I'm putting all of [segment's context](https://segment.com/docs/connections/spec/common/#context) into the properties. I'm stripping out a couple of properties and replacing them with our versions (see contextMapping).

There are still _a lot_ of properties that I haven't mapped and haven't stripped out. I think I'm okay leaving these in for now though the experience is a little bit weird as you now have a combination of posthog properties and segment properties.

![image](https://user-images.githubusercontent.com/1727427/138901007-8966da91-1f4f-440b-99d5-aa557a54a207.png)


Closes #4 
Closes #3