### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ async function onTrack(event, settings) {
             api_key: settings.apiKey,
             properties: {
                 ...event.properties,
-                $browser: determineBrowser(navigator.userAgent, navigator.vendor, window.opera),
+                ...(event.properties.browser ? { $browser: event.properties.browser } : {}),             
                 distinct_id: event.userId || event.anonymousId,
             },
         }),
@@ -115,48 +115,3 @@ async function onScreen(event, settings) {
     )
 }
 
-function determineBrowser (user_agent, vendor, opera) {
-    vendor = vendor || '' // vendor is undefined for at least IE9
-    if (opera || _.includes(user_agent, ' OPR/')) {
-        if (_.includes(user_agent, 'Mini')) {
-            return 'Opera Mini'
-        }
-        return 'Opera'
-    } else if (/(BlackBerry|PlayBook|BB10)/i.test(user_agent)) {
-        return 'BlackBerry'
-    } else if (_.includes(user_agent, 'IEMobile') || _.includes(user_agent, 'WPDesktop')) {
-        return 'Internet Explorer Mobile'
-    } else if (_.includes(user_agent, 'SamsungBrowser/')) {
-        // https://developer.samsung.com/internet/user-agent-string-format
-        return 'Samsung Internet'
-    } else if (_.includes(user_agent, 'Edge') || _.includes(user_agent, 'Edg/')) {
-        return 'Microsoft Edge'
-    } else if (_.includes(user_agent, 'FBIOS')) {
-        return 'Facebook Mobile'
-    } else if (_.includes(user_agent, 'Chrome')) {
-        return 'Chrome'
-    } else if (_.includes(user_agent, 'CriOS')) {
-        return 'Chrome iOS'
-    } else if (_.includes(user_agent, 'UCWEB') || _.includes(user_agent, 'UCBrowser')) {
-        return 'UC Browser'
-    } else if (_.includes(user_agent, 'FxiOS')) {
-        return 'Firefox iOS'
-    } else if (_.includes(vendor, 'Apple')) {
-        if (_.includes(user_agent, 'Mobile')) {
-            return 'Mobile Safari'
-        }
-        return 'Safari'
-    } else if (_.includes(user_agent, 'Android')) {
-        return 'Android Mobile'
-    } else if (_.includes(user_agent, 'Konqueror')) {
-        return 'Konqueror'
-    } else if (_.includes(user_agent, 'Firefox')) {
-        return 'Firefox'
-    } else if (_.includes(user_agent, 'MSIE') || _.includes(user_agent, 'Trident/')) {
-        return 'Internet Explorer'
-    } else if (_.includes(user_agent, 'Gecko')) {
-        return 'Mozilla'
-    } else {
-        return ''
-    }
-},

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ async function onTrack(event, settings) {
             api_key: settings.apiKey,
             properties: {
                 ...event.properties,
+                $browser: determineBrowser(navigator.userAgent, navigator.vendor, window.opera),
                 distinct_id: event.userId || event.anonymousId,
             },
         }),
@@ -113,3 +114,49 @@ async function onScreen(event, settings) {
         settings
     )
 }
+
+function determineBrowser (user_agent, vendor, opera) {
+    vendor = vendor || '' // vendor is undefined for at least IE9
+    if (opera || _.includes(user_agent, ' OPR/')) {
+        if (_.includes(user_agent, 'Mini')) {
+            return 'Opera Mini'
+        }
+        return 'Opera'
+    } else if (/(BlackBerry|PlayBook|BB10)/i.test(user_agent)) {
+        return 'BlackBerry'
+    } else if (_.includes(user_agent, 'IEMobile') || _.includes(user_agent, 'WPDesktop')) {
+        return 'Internet Explorer Mobile'
+    } else if (_.includes(user_agent, 'SamsungBrowser/')) {
+        // https://developer.samsung.com/internet/user-agent-string-format
+        return 'Samsung Internet'
+    } else if (_.includes(user_agent, 'Edge') || _.includes(user_agent, 'Edg/')) {
+        return 'Microsoft Edge'
+    } else if (_.includes(user_agent, 'FBIOS')) {
+        return 'Facebook Mobile'
+    } else if (_.includes(user_agent, 'Chrome')) {
+        return 'Chrome'
+    } else if (_.includes(user_agent, 'CriOS')) {
+        return 'Chrome iOS'
+    } else if (_.includes(user_agent, 'UCWEB') || _.includes(user_agent, 'UCBrowser')) {
+        return 'UC Browser'
+    } else if (_.includes(user_agent, 'FxiOS')) {
+        return 'Firefox iOS'
+    } else if (_.includes(vendor, 'Apple')) {
+        if (_.includes(user_agent, 'Mobile')) {
+            return 'Mobile Safari'
+        }
+        return 'Safari'
+    } else if (_.includes(user_agent, 'Android')) {
+        return 'Android Mobile'
+    } else if (_.includes(user_agent, 'Konqueror')) {
+        return 'Konqueror'
+    } else if (_.includes(user_agent, 'Firefox')) {
+        return 'Firefox'
+    } else if (_.includes(user_agent, 'MSIE') || _.includes(user_agent, 'Trident/')) {
+        return 'Internet Explorer'
+    } else if (_.includes(user_agent, 'Gecko')) {
+        return 'Mozilla'
+    } else {
+        return ''
+    }
+},


### PR DESCRIPTION
Customer request for tracking `$browser` here.

Segment automatically tracks `browser` so I'm not sure if we should instead just point users to using transformations https://segment.com/docs/protocols/transform/ as this will cause browser to be passed twice.