### PR TITLE
fix sending without properties set

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,11 @@ async function onTrack(event, settings) {
     if (event.properties && event.properties.utm_name) {
         event.properties["utm_campaign"] = event.properties.utm_name
     }
+  
+    if (event.properties && event.properties.browser) {
+        event.properties["$browser"] = event.properties.browser
+    }
+  
 
     const res = await fetch(endpoint, {
         body: JSON.stringify({
@@ -57,7 +62,6 @@ async function onTrack(event, settings) {
             properties: {
                 ...parseContext(event.context),
                 ...event.properties,
-                ...(event.properties.browser ? { $browser: event.properties.browser } : {}),             
                 distinct_id: event.userId || event.anonymousId,
                 $lib: 'Segment'
             },


### PR DESCRIPTION
Annoyingly we introduced a bug where if we didn't send properties segment would fail