### PR TITLE
Segment to match alias changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,8 +134,8 @@ async function onAlias(event, settings) {
             ...event,
             event: '$create_alias',
             properties: {
-                alias: event.previousId,
-                distinct_id: event.userId,
+                alias: event.userId,
+                distinct_id: event.previousId,
             },
         },
         settings


### PR DESCRIPTION
Part of https://github.com/PostHog/posthog/issues/11873

We should pass the userID as distinctID and anonymous/previous id as alias

According to Segment docs https://segment.com/docs/connections/spec/alias/
> If you’re using Segment’s JavaScript library, Segment automatically passes in the user’s `anonymousId` as `previousId` for you.

Our docs https://posthog.com/docs/integrate/identifying-users
> We do not allow merging from an already identified user (distinct_id user can be previously identified, but anon_distinct_id and alias user cannot).