### PR TITLE
Add support for groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function onTrack(event, settings) {
         event.properties["$browser"] = event.properties.browser
     }
   
-  	if (event.context && event.context.groupId) {
+    if (event.context && event.context.groupId) {
         event.properties["$groups"] = {"segment_group": event.context.groupId}
     }
   

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function onTrack(event, settings) {
         event.properties["$browser"] = event.properties.browser
     }
   
-  	if (event.context.groupId) {
+  	if (event.context && event.context.groupId) {
         event.properties["$groups"] = {"segment_group": event.context.groupId}
     }
   

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ function parseContext(context) {
   let ret = {}
   if(context.campaign) {
     Object.entries(context.campaign).map(function([key, value]) {
+      if(key === 'name') key = 'campaign'
       ret['utm_' + key] = value
     })
     delete context['campaign']

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ function parseContext(context) {
   let ret = {}
   if(context.campaign) {
     Object.entries(context.campaign).map(function([key, value]) {
-      if(key === 'name') key = 'campaign'
       ret['utm_' + key] = value
     })
     delete context['campaign']
@@ -53,6 +52,10 @@ async function onTrack(event, settings) {
   
     if (event.properties && event.properties.browser) {
         event.properties["$browser"] = event.properties.browser
+    }
+  
+  	if (event.context.groupId) {
+        event.properties["$groups"] = {"segment_group": event.context.groupId}
     }
   
 
@@ -105,7 +108,18 @@ async function onIdentify(event, settings) {
  * @return any
  */
 async function onGroup(event, settings) {
-    throw new EventNotSupported('on groups is not supported')
+    return await onTrack(
+        {
+            ...event,
+            event: '$groupidentify',
+            properties: {
+              "$group_type": "segment_group",
+              "$group_key": event.groupId,
+              "$group_set": event.traits
+            },
+        },
+        settings
+    )
 }
 
 /**
@@ -160,4 +174,3 @@ async function onScreen(event, settings) {
         settings
     )
 }
-


### PR DESCRIPTION
Segment only supports one group type, so I'm explicitly putting that in a segment_group type to separate it from others.