### PR TITLE
Catch Segment error when properties aren't sent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ async function onTrack(event, settings) {
     }
   
     if (event.context && event.context.groupId) {
+        if(!event.properties) {
+          event.properties = {}
+        }
         event.properties["$groups"] = {"segment_group": event.context.groupId}
     }
   


### PR DESCRIPTION
If you try sending a groupId in the context but didn't set the `properties` field you get the below error:
```
[
  {
    "body": "{\"errorType\":\"TypeError\",\"errorMessage\":\"Cannot set property '$groups' of undefined\",\"trace\":[\"TypeError: Cannot set property '$groups' of undefined\",\"    at onTrack (handler.js:59:37)\",\"    at Runtime.exports.processDestinationPayload [as handler] (/var/task/index.js:137:18)\",\"    at Runtime.handleOnceNonStreaming (/var/runtime/Runtime.js:74:25)\"]}",
    "header": {
      "Connection": "keep-alive",
      "Content-Length": "351",
      "Content-Type": "application/json",
      "Date": "Wed, 22 Mar 2023 12:57:19 GMT",
      "X-Amz-Executed-Version": "<REDACTED>",
      "X-Amz-Function-Error": "<REDACTED>",
      "X-Amz-Log-Result": "<REDACTED>",
      "X-Amzn-Remapped-Content-Length": "<REDACTED>",
      "X-Amzn-Requestid": "<REDACTED>",
      "X-Amzn-Trace-Id": "<REDACTED>"
    },
    "status": 200
  }
]
```

This PR fixes that.