### PR TITLE
fix: alias has user and previous swapped

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,16 @@ async function onTrack(event, settings) {
         event.properties['$groups'] = { segment_group: event.context.groupId }
     }
 
+    // In alias cases, we set the distinct id explicitly and it has to be what's expected. In all other
+    // cases, we use the userId if it exists, otherwise the anonymousId.
+    let distinct_id = null;
+
+    if (event.event === '$create_alias') {
+        distinct_id = event.properties.distinct_id;
+    } else {
+        distinct_id = event.userId || event.anonymousId;
+    }
+
     const res = await fetch(endpoint, {
         body: JSON.stringify({
             uuid,
@@ -77,7 +87,7 @@ async function onTrack(event, settings) {
             properties: {
                 ...parseContext(event.context),
                 ...event.properties,
-                distinct_id: event.userId || event.anonymousId,
+                distinct_id: distinct_id,
                 $lib: 'Segment',
             },
         }),

--- a/index.js
+++ b/index.js
@@ -174,8 +174,8 @@ async function onAlias(event, settings) {
             ...event,
             event: '$create_alias',
             properties: {
-                alias: event.previousId,
-                distinct_id: event.userId,
+                alias: event.userId,
+                distinct_id: event.previousId,
             },
         },
         settings

--- a/test.js
+++ b/test.js
@@ -270,8 +270,8 @@ describe('Segment Integration', () => {
                     segment_ip: '8.8.8.8',
                     segment_userAgent:
                         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36',
-                    alias: '39239-239239-239239-23923',
-                    distinct_id: '507f191e81',
+                    alias: '507f191e81',
+                    distinct_id: '39239-239239-239239-23923',
                     $lib: 'Segment',
                 },
             })


### PR DESCRIPTION
According to [this ticket](https://posthoghelp.zendesk.com/agent/tickets/19587), which seems correct - [we say](https://posthog.com/docs/api/capture#alias):
```
curl -v -L --header "Content-Type: application/json" -d '{
  "api_key": "phc_ejMSkPyupG4rM4ABd7vPKSSJrnEnZiVS29ggGoCfdS1",
  "event": "$create_alias",
  "distinct_id": "123",
  "properties": {
    "alias": "456"
  }
}' https://us.i.posthog.com/capture/
```
> In this example, 123 is merged into 456 **and 456 becomes the main distinct_id for events associated with 123**.

[Segment says](https://segment.com/docs/connections/spec/alias/):
> The userId is a string that will be the user’s new identity, or an existing identity that you wish to merge with the previousId

Fairly sure that means `alias` should be `userId`